### PR TITLE
Disable line display by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       <div class="controls">
         <div class="control-group">
           <label>
-            <input type="checkbox" id="showLineCheckbox" checked>
+            <input type="checkbox" id="showLineCheckbox">
             Visa linje
           </label>
         </div>


### PR DESCRIPTION
## Summary
- remove the default checked state from the "Visa linje" checkbox so the regression line is hidden on page load

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0dd2c29a8832b9d47126bbb9f2a15