### PR TITLE
Dela upp reglagen under diagrammet i två paneler

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,49 +24,56 @@
     <div class="plot-container">
       <canvas id="plotCanvas" width="600" height="500"></canvas>
       <div class="controls">
-        <div class="control-group">
-          <label>
-            <input type="checkbox" id="showLineCheckbox">
-            Visa linje
-          </label>
+        <div class="control-panel">
+          <h3>Linje</h3>
+          <div class="control-group">
+            <label>
+              <input type="checkbox" id="showLineCheckbox">
+              Visa linje
+            </label>
+          </div>
+          <div class="control-group">
+            <label for="kSlider">Vikt w:</label>
+            <input type="range" id="kSlider" min="0" max="0.1" step="0.001" value="0.1">
+          </div>
+          <div class="control-group">
+            <label for="mSlider">Bias/intercept b:</label>
+            <input type="range" id="mSlider" min="0" max="1" step="0.01" value="0">
+          </div>
+          <div class="control-group equation blue" id="lineEquation">
+            y = 0.100x + 0.00
+          </div>
         </div>
-        <div class="control-group">
-          <label for="kSlider">Vikt w:</label>
-          <input type="range" id="kSlider" min="0" max="0.1" step="0.001" value="0.1">
-        </div>
-        <div class="control-group">
-          <label for="mSlider">Bias/intercept b:</label>
-          <input type="range" id="mSlider" min="0" max="1" step="0.01" value="0">
-        </div>
-        <div class="control-group equation blue" id="lineEquation">
-          y = 0.100x + 0.00
-        </div>
-        <div class="control-group">
-          <label>
-            <input type="checkbox" id="showErrorCheckbox">
-            Visa fel
-          </label>
-        </div>
-        <div class="control-group error red" id="lineError">
-          Fel(k, m) = 0.00
-        </div>
-        <div class="control-group">
-          <label>
-            <input type="checkbox" id="showOptimalCheckbox">
-            Visa optimal linje
-          </label>
-        </div>
-        <div class="control-group equation green" id="optimalEquation"></div>
-        <div class="control-group">
-          <label>
-            <input type="checkbox" id="doPredictionCheckbox">
-            Gör prediktion
-          </label>
-        </div>
-        <div class="control-group prediction" id="predictionGroup">
-          <label for="predictionInput">Area (kvm):</label>
-          <input type="number" id="predictionInput" min="0" step="0.1">
-          <span id="predictedPrice" class="equation blue"></span>
+
+        <div class="control-panel">
+          <h3>Analys & prediktion</h3>
+          <div class="control-group">
+            <label>
+              <input type="checkbox" id="showErrorCheckbox">
+              Visa fel
+            </label>
+          </div>
+          <div class="control-group error red" id="lineError">
+            Fel(k, m) = 0.00
+          </div>
+          <div class="control-group">
+            <label>
+              <input type="checkbox" id="showOptimalCheckbox">
+              Visa optimal linje
+            </label>
+          </div>
+          <div class="control-group equation green" id="optimalEquation"></div>
+          <div class="control-group">
+            <label>
+              <input type="checkbox" id="doPredictionCheckbox">
+              Gör prediktion
+            </label>
+          </div>
+          <div class="control-group prediction" id="predictionGroup">
+            <label for="predictionInput">Area (kvm):</label>
+            <input type="number" id="predictionInput" min="0" step="0.1">
+            <span id="predictedPrice" class="equation blue"></span>
+          </div>
         </div>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -63,8 +63,22 @@ table th {
 .controls {
   margin-top: 15px;
   display: flex;
-  flex-direction: column;
-  gap: 10px;
+  gap: 16px;
+}
+
+.control-panel {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 12px;
+  background: #fafafa;
+}
+
+.control-panel h3 {
+  margin: 0 0 10px;
+  color: #333;
+  font-size: 16px;
 }
 
 .control-group {
@@ -102,4 +116,10 @@ table th {
 .prediction input {
   width: 80px;
   padding: 3px;
+}
+
+@media (max-width: 900px) {
+  .controls {
+    flex-direction: column;
+  }
 }


### PR DESCRIPTION
### Motivation
- Gör kontrollområdet under ploten mer överskådligt genom att separera linjens inställningar från analys- och prediktionsverktygen.

### Description
- Delade upp markup i `index.html` och kapslade reglagen i två kolumner genom att införa två `div.control-panel`-sektioner: vänster panel `Linje` (`Visa linje`, `k`- och `b`-reglage och linjeekvationen) och höger panel `Analys & prediktion` (`Visa fel`, `Visa optimal linje`, `Gör prediktion` och prediktionsfältet).
- Lade till ny styling i `style.css` för `.control-panel` och ändrade `.controls` till horisontell flex-layout med gap, samt en responsiv media query som staplar panelerna vertikalt på smalare skärmar.
- Behöll befintliga element-id:n och JavaScript-logik så att `script.js` fortsatt fungerar utan kodändringar.

### Testing
- Startade lokal webbserver med `python -m http.server 4173` och gjorde visuell verifiering av layouten via en Playwright-skript som tog en skärmdump (screenshot) av den nya panel-layouten; verifiering lyckades.
- Körde JavaScript-syntaxkontroll med `node --check script.js` och den rapporterade inga fel.
- Ändringarna committades lokalt efter verifiering (`git commit`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ec605c600832b94befbaf2a9c3b68)