### PR TITLE
Visa RMSE-text endast när "Visa fel" är ikryssad

### DIFF
--- a/script.js
+++ b/script.js
@@ -214,7 +214,7 @@ function drawPlot() {
       ctx.setLineDash([]);
       lineErrorElem.textContent = `Medelfel RMSE(w, b) = ${calculateRmse(k, m).toFixed(3)}`;
     } else {
-      lineErrorElem.textContent = "Medelfel RMSE(w, b) = -";
+      lineErrorElem.textContent = "";
     }
   } else {
     lineEquationElem.textContent = "";


### PR DESCRIPTION
### Motivation
- Förhindra att RMSE-texten `Medelfel RMSE(w, b) = ...` visas när endast `Visa linje` är ikryssad och bara visa den när `Visa fel` är aktiverad för tydligare UI-beteende.

### Description
- I `drawPlot()` i `script.js` ändrades logiken så att `lineErrorElem` sätts till en tom sträng (`""`) när `showLineCheckbox` är ikryssad men `showErrorCheckbox` inte är ikryssad, istället för att visa `"Medelfel RMSE(w, b) = -"`.

### Testing
- Körda automatiska kontroller: `git diff -- script.js` visade förväntad diff och filen committades framgångsrikt; en lokal `python3 -m http.server` kördes för att ladda sidan; en Playwright-skript kördes för att ta en skärmdump med `Visa linje` ikryssad och `Visa fel` av, vilket verifierade att RMSE-texten inte visas; alla steg slutfördes utan fel.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ec650e80c832b8511e1e3810f64c9)