### PR TITLE
Förbättra radbrytning och minska panelhopp i regression-UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <div class="plot-container">
       <canvas id="plotCanvas" width="600" height="500"></canvas>
       <div class="controls">
-        <div class="control-panel">
+        <div class="control-panel line-panel">
           <h3>Linje</h3>
           <div class="control-group">
             <label>
@@ -45,7 +45,7 @@
           </div>
         </div>
 
-        <div class="control-panel">
+        <div class="control-panel analysis-panel">
           <h3>Analys & prediktion</h3>
           <div class="control-group">
             <label>
@@ -69,7 +69,7 @@
               Gör prediktion
             </label>
           </div>
-          <div class="control-group prediction" id="predictionGroup">
+          <div class="control-group prediction hidden" id="predictionGroup">
             <label for="predictionInput">Area (kvm):</label>
             <input type="number" id="predictionInput" min="0" step="0.1">
             <span id="predictedPrice" class="equation blue"></span>

--- a/script.js
+++ b/script.js
@@ -239,7 +239,7 @@ function drawPlot() {
     const mOpt = (sumY - kOpt * sumX) / n;
 
     const rmseOpt = calculateRmse(kOpt, mOpt);
-    optimalEquationElem.innerHTML = `Optimal linje: y = ${kOpt.toFixed(3)}x + ${mOpt.toFixed(2)} <span class="error red">RMSE(w, b) = ${rmseOpt.toFixed(3)}</span>`;
+    optimalEquationElem.innerHTML = `Optimal linje: y = ${kOpt.toFixed(3)}x + ${mOpt.toFixed(2)}<br><span class="error red">RMSE(w, b) = ${rmseOpt.toFixed(3)}</span>`;
 
     ctx.strokeStyle = "green";
     ctx.lineWidth = 2;
@@ -256,12 +256,12 @@ function drawPlot() {
 
 function updatePrediction() {
   if (!doPredictionCheckbox.checked) {
-    predictionGroup.style.display = "none";
+    predictionGroup.classList.add("hidden");
     predictedPriceElem.textContent = "";
     return;
   }
 
-  predictionGroup.style.display = "flex";
+  predictionGroup.classList.remove("hidden");
   const areaVal = parseFloat(predictionInput.value);
   if (!Number.isNaN(areaVal)) {
     const k = parseFloat(kSlider.value);

--- a/style.css
+++ b/style.css
@@ -95,6 +95,12 @@ table th {
   margin-left: 10px;
 }
 
+#lineEquation,
+#lineError,
+#optimalEquation {
+  min-height: 1.2em;
+}
+
 .equation.blue {
   color: blue;
 }
@@ -108,14 +114,27 @@ table th {
 }
 
 .prediction {
-  display: none;
+  display: flex;
   align-items: center;
   gap: 10px;
+}
+
+.prediction.hidden {
+  visibility: hidden;
 }
 
 .prediction input {
   width: 80px;
   padding: 3px;
+}
+
+
+.line-panel {
+  min-height: 220px;
+}
+
+.analysis-panel {
+  min-height: 220px;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
### Motivation
- Användaren ville att texten för "Visa optimal linje" ska visa RMSE på ny rad istället för efter ett mellanslag och att kontrollpanelerna för "Linje" och "Analys & prediktion" ska ha sin maximala storlek från början för att undvika layouthopp när komponenter slås på/av.

### Description
- Lagt till en radbrytning i `script.js` så att `optimalEquation` renderar RMSE på egen rad (`<br>`). 
- Uppdaterat toggling för prediktion så att `predictionGroup` initialt har klassen `hidden` i `index.html` och att JavaScript växlar klassen istället för att byta `display`, för att bibehålla layoutplats. 
- Lagt till panel-specifika klasser `line-panel` och `analysis-panel` i `index.html` samt CSS-regler i `style.css` som sätter `min-height` för panelerna och en minhöjd för textytor (`#lineEquation`, `#lineError`, `#optimalEquation`) och en `visibility: hidden`-variant för `.prediction.hidden` för att reservera utrymme.

### Testing
- Körkontroll av JavaScript-syntax med `node --check script.js` kördes och lyckades.
- Startade en lokal statisk server med `python3 -m http.server` och körde en Playwright-skript som automatiserat öppnade sidan och genererade en UI-screenshot som verifierar att panelerna har reserverad plats och att RMSE ligger på ny rad (screenshot skapad som automatiserat artifact vid testkörning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ec8f90f10832ba42ad3a3636e0d81)